### PR TITLE
feat: unittest environment is same as local

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -3,8 +3,10 @@
 const assert = require('assert');
 const DevServer = require('./lib/dev_server');
 
-module.exports = agent => {
-  if (!agent.config.assets.isLocal) return;
+module.exports = agent => startDevServer(agent);
+
+function startDevServer(agent) {
+  if (!agent.config.assets.isLocalOrUnittest) return;
   if (!agent.config.assets.devServer.enable) return;
 
   assert(agent.config.assets.devServer.port, 'devServer.port is required when devServer is enabled');
@@ -23,4 +25,4 @@ module.exports = agent => {
   agent.beforeClose(async () => {
     await server.close();
   });
-};
+}

--- a/app.js
+++ b/app.js
@@ -8,11 +8,12 @@ const AssetsView = require('./lib/assets_view');
 module.exports = app => {
   const assetsConfig = app.config.assets;
 
-  if (assetsConfig.devServer.enable && assetsConfig.isLocal) {
+  if (assetsConfig.devServer.enable && assetsConfig.isLocalOrUnittest) {
     assetsConfig.url = 'http://127.0.0.1:' + assetsConfig.devServer.port;
   }
 
-  if (!assetsConfig.isLocal) {
+  // it should check manifest.json on deployment
+  if (!assetsConfig.isLocalOrUnittest) {
     const manifestPath = path.join(app.config.baseDir, 'config/manifest.json');
     assert(fs.existsSync(manifestPath), `${manifestPath} is required`);
     assetsConfig.manifest = require(manifestPath);

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -18,7 +18,7 @@ module.exports = appInfo => ({
    * @property {Boolean} devServer.waitStart - whether wait devServer starting
    */
   assets: {
-    isLocal: appInfo.env === 'local',
+    isLocalOrUnittest: appInfo.env === 'local' || appInfo.env === 'unittest',
     url: '',
     publicPath: '',
     templatePath: '',

--- a/lib/assets_context.js
+++ b/lib/assets_context.js
@@ -15,10 +15,10 @@ class Assets {
   constructor(ctx) {
     this.ctx = ctx;
     this.config = ctx.app.config.assets;
-    this.isLocal = this.config.isLocal;
+    this.isLocalOrUnittest = this.config.isLocalOrUnittest;
     this.manifest = this.config.manifest;
     // publicPath should contain trailing / and leading /
-    this.publicPath = this.isLocal ? '/' : normalizePublicPath(this.config.publicPath);
+    this.publicPath = this.isLocalOrUnittest ? '/' : normalizePublicPath(this.config.publicPath);
   }
 
   get host() {
@@ -54,7 +54,7 @@ class Assets {
 
   getURL(entry) {
     let urlpath = entry;
-    if (!this.isLocal) {
+    if (!this.isLocalOrUnittest) {
       urlpath = this.manifest[urlpath];
       assert(urlpath, `Don't find ${entry} in manifest.json`);
     }

--- a/test/assets.test.js
+++ b/test/assets.test.js
@@ -365,4 +365,41 @@ describe('test/assets.test.js', () => {
       });
     });
   });
+
+  describe('manifest checking', () => {
+    let app;
+    afterEach(() => app.close());
+
+    it('should check manifest.json on prod', async () => {
+      mock.env('prod');
+      app = mock.app({
+        baseDir: 'apps/no-manifest',
+      });
+      // app.debug();
+      try {
+        await app.ready();
+        throw new Error('should not run');
+      } catch (err) {
+        assert(err.message === path.join(__dirname, 'fixtures/apps/no-manifest/config/manifest.json') + ' is required');
+      }
+    });
+
+    it('should not check manifest.json on local', async () => {
+      mock.env('local');
+      app = mock.app({
+        baseDir: 'apps/no-manifest',
+      });
+      // app.debug();
+      await app.ready();
+    });
+
+    it('should not check manifest.json on unittest', async () => {
+      mock.env('unittest');
+      app = mock.app({
+        baseDir: 'apps/no-manifest',
+      });
+      // app.debug();
+      await app.ready();
+    });
+  });
 });

--- a/test/fixtures/apps/no-manifest/config/config.default.js
+++ b/test/fixtures/apps/no-manifest/config/config.default.js
@@ -3,6 +3,5 @@
 exports.assets = {
   devServer: {
     enable: false,
-    waitStart: true,
   },
 };

--- a/test/fixtures/apps/no-manifest/package.json
+++ b/test/fixtures/apps/no-manifest/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "egg-view-assets"
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

- don't check manifest.json on unittest
- but devServer is disabled by default