### PR TITLE
feat: make sure `__webpack_public_path__` inserted just once

### DIFF
--- a/lib/assets_context.js
+++ b/lib/assets_context.js
@@ -17,6 +17,8 @@ class Assets {
     this.crossorigin = this.config.crossorigin;
     // publicPath should contain trailing / and leading /
     this.publicPath = this.isLocalOrUnittest ? '/' : normalizePublicPath(this.config.publicPath);
+    // make sure __webpack_public_path__ inserted just once
+    this.hasWebpackGlobalVariableInserted = false;
   }
 
   get host() {
@@ -36,8 +38,9 @@ class Assets {
     entry = entry || this.entry;
 
     let script = '';
-    if (this.publicPath) {
+    if (this.publicPath && !this.hasWebpackGlobalVariableInserted) {
       script = `<script>window.__webpack_public_path__ = '${this.publicPath}';</script>`;
+      this.hasWebpackGlobalVariableInserted = true;
     }
 
     script += scriptTpl({

--- a/test/assets.test.js
+++ b/test/assets.test.js
@@ -489,4 +489,33 @@ describe('test/assets.test.js', () => {
       assert(script.includes('crossorigin'));
     });
   });
+
+  describe('should insert webpack global variable just once', () => {
+    let app;
+    before(() => {
+      mock.env('default');
+      app = mock.app({
+        baseDir: 'apps/multiple-getscript',
+      });
+      return app.ready();
+    });
+
+    after(() => app.close());
+    afterEach(mock.restore);
+
+    it('should works', () => {
+      const ctx = app.mockContext();
+
+      const script = ctx.helper.assets.getScript('vendor.js');
+      assert(script.includes('__webpack_public_path__ = \'/\';'));
+      assert(script.includes('src="/vendor.js"'));
+
+      [ 'a.js', 'b.js', 'c.js' ].forEach(file => {
+        const anotherScript = ctx.helper.assets.getScript(file);
+        assert(!anotherScript.includes('__webpack_public_path__'));
+        assert(anotherScript.includes(`src="/${file}"`));
+      });
+
+    });
+  });
 });

--- a/test/fixtures/apps/multiple-getscript/app/controller/home.js
+++ b/test/fixtures/apps/multiple-getscript/app/controller/home.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const Controller = require('egg').Controller;
+
+class HomeController extends Controller {
+  async index() {
+    await this.ctx.render('index.js');
+  }
+}
+
+module.exports = HomeController;

--- a/test/fixtures/apps/multiple-getscript/app/router.js
+++ b/test/fixtures/apps/multiple-getscript/app/router.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = app => {
+  const { router, controller } = app;
+
+  router.get('/', controller.home.index);
+};

--- a/test/fixtures/apps/multiple-getscript/config/config.default.js
+++ b/test/fixtures/apps/multiple-getscript/config/config.default.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.keys = '123456';
+exports.view = {
+  mapping: {
+    '.js': 'assets',
+  },
+};
+exports.assets = {
+  devServer: {
+    enable: false,
+  },
+};

--- a/test/fixtures/apps/multiple-getscript/config/manifest.json
+++ b/test/fixtures/apps/multiple-getscript/config/manifest.json
@@ -1,0 +1,6 @@
+{
+  "vendor.js": "vendor.js",
+  "a.js": "a.js",
+  "b.js": "b.js",
+  "c.js": "c.js"
+}

--- a/test/fixtures/apps/multiple-getscript/package.json
+++ b/test/fixtures/apps/multiple-getscript/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "multiple-getscript"
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
When we execute `getScript()` multiple times, should insert `__webpack_public_path__` just once.

Example
```njk
{{ helper.assets.getScript('vendors.js') | safe }}
{{ helper.assets.getScript('a.js') | safe }}
{{ helper.assets.getScript('b.js') | safe }}
{{ helper.assets.getScript('c.js') | safe }}
```
![image](https://user-images.githubusercontent.com/5064777/56851171-a2b26580-693e-11e9-86e3-3c0610697ac6.png)
