### PR TITLE
【BUG】修复问题：autoPort为true时，port数据格式和fs模块要求数据格式不匹配

### DIFF
--- a/lib/dev_server.js
+++ b/lib/dev_server.js
@@ -28,7 +28,7 @@ class DevServer extends Base {
     if (devServer.autoPort) {
       devServer.port = await detectPort(10000);
       await mkdirp(path.dirname(devServer.portPath));
-      await fs.writeFile(devServer.portPath, devServer.port);
+      await fs.writeFile(devServer.portPath, devServer.port.toString());
     } else {
       // check whether the port is using
       if (await this.checkPortExist()) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
autoPort为true，自动侦测出来的port 是number类型，但是 `fs.writeFile` 要求的是 字符串或buffer二进制数据
