### PR TITLE
feat: start detecting port from devServer.port

### DIFF
--- a/lib/dev_server.js
+++ b/lib/dev_server.js
@@ -4,7 +4,6 @@ const path = require('path');
 const fs = require('mz/fs');
 const spawn = require('cross-spawn');
 const Base = require('sdk-base');
-const detect = require('detect-port');
 const sleep = require('mz-modules/sleep');
 const awaitEvent = require('await-event');
 const debug = require('debug')('egg-view-assets:dev_server');
@@ -26,7 +25,7 @@ class DevServer extends Base {
     const { devServer } = this.app.config.assets;
 
     if (devServer.autoPort) {
-      devServer.port = await detectPort(10000);
+      devServer.port = await detectPort(devServer.port || 10000);
       await mkdirp(path.dirname(devServer.portPath));
       await fs.writeFile(devServer.portPath, devServer.port.toString());
     } else {
@@ -66,7 +65,7 @@ class DevServer extends Base {
 
   async checkPortExist() {
     const { devServer } = this.app.config.assets;
-    const port = await detect(devServer.port);
+    const port = await detectPort(devServer.port);
     debug('check %s, get result %s', devServer.port, port);
     return port !== devServer.port;
   }

--- a/test/dev_server.test.js
+++ b/test/dev_server.test.js
@@ -193,4 +193,37 @@ describe('test/dev_server.test.js', () => {
       await app1.close();
     }
   });
+
+  it('should auto check port with autoPort and port offset', async () => {
+    mock.env('local');
+    const app1 = mock.cluster({
+      baseDir: 'apps/autoport-offset',
+    });
+
+    await app1.ready();
+
+    await app1.httpRequest()
+      .get('/')
+      .expect(/http:\/\/127.0.0.1:8000\/index.js/)
+      .expect(200);
+    await app1.httpRequest()
+      .get('/port')
+      .expect('8000')
+      .expect(200);
+
+    app1.expect('stdout', /\[server] listening 8000/);
+    app1.expect('stdout', /\[server] SOCKET_SERVER: http:\/\/127.0.0.1:8000/);
+
+    app = mock.cluster({
+      baseDir: 'apps/autoport-offset',
+    });
+    // app.debug();
+    try {
+      await app.ready();
+
+      app.expect('stdout', /\[server] listening 8001/);
+    } finally {
+      await app1.close();
+    }
+  });
 });

--- a/test/fixtures/apps/autoport-offset/app/controller/home.js
+++ b/test/fixtures/apps/autoport-offset/app/controller/home.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const Controller = require('egg').Controller;
+
+class HomeController extends Controller {
+  async index() {
+    await this.ctx.render('index.js');
+  }
+
+  async port() {
+    this.ctx.body = this.app.config.assets.devServer.port;
+  }
+}
+
+module.exports = HomeController;

--- a/test/fixtures/apps/autoport-offset/app/router.js
+++ b/test/fixtures/apps/autoport-offset/app/router.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = app => {
+  const { router, controller } = app;
+
+  router.get('/', controller.home.index);
+  router.get('/port', controller.home.port);
+};

--- a/test/fixtures/apps/autoport-offset/config/config.default.js
+++ b/test/fixtures/apps/autoport-offset/config/config.default.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const path = require('path');
+
+exports.keys = '123456';
+exports.view = {
+  mapping: {
+    '.js': 'assets',
+    '.jsx': 'assets',
+  },
+};
+exports.assets = {
+  devServer: {
+    waitStart: true,
+    autoPort: true,
+    port: 8000,
+    command: 'node ' + path.join(__dirname, '../../mocktool/server.js') + ' {port}',
+    env: {
+      SOCKET_SERVER: 'http://127.0.0.1:{port}',
+    },
+    debug: true,
+  },
+};

--- a/test/fixtures/apps/autoport-offset/package.json
+++ b/test/fixtures/apps/autoport-offset/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "egg-view-assets"
+}


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
N/A


##### Description of change
When `devServer.autoPort` and `devServer.port` are both set, start detecting port from given `devServer.port`
