### PR TITLE
fix: the paths should be separated by ';'

### DIFF
--- a/lib/dev_server.js
+++ b/lib/dev_server.js
@@ -50,9 +50,9 @@ class DevServer extends Base {
     const binDir = path.join(this.app.config.baseDir, 'node_modules', '.bin');
     if (process.platform === 'win32') {
       if (env.PATH) {
-        env.PATH = `${binDir}:${env.PATH}`;
+        env.PATH = `${binDir};${env.PATH}`;
       } else if (env.Path) {
-        env.Path = `${binDir}:${env.Path}`;
+        env.Path = `${binDir};${env.Path}`;
       } else {
         throw new Error('env.PATH or env.Path not found');
       }


### PR DESCRIPTION
closes https://github.com/eggjs/egg/issues/5187

#44 #45 ，我本地升版之后，虽然Window地址的拼接已经正确，但是中间的符号还是错误。应该使用;，而不是:，否则还是会造成地址不正确而出现命令无法正确执行的情况