### PR TITLE
feat: change __webpack_public_path__ var value to assets.resourceBase

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -8,6 +8,7 @@ module.exports = appInfo => ({
    * @member Config#assets
    * @property {String} url - the host of the assets, it will be `http://127.0.0.1:${devServer.port}` in development.
    * @property {String} publicPath - the base path of the assets
+   * @property {Boolean} resourcePathToURL - convert the value `window.__webpack_public_path__` of the variable into url/publicPath, default is false
    * @property {String} templatePath - the file path of template rendering html
    * @property {String} templateViewEngine - the view engine for rendering template
    * @property {Boolean} crossorigin - if script is cross origin set this config to true
@@ -25,6 +26,7 @@ module.exports = appInfo => ({
     isLocalOrUnittest: appInfo.env === 'local' || appInfo.env === 'unittest',
     url: '',
     publicPath: '',
+    resourcePathToURL: false,
     templatePath: '',
     templateViewEngine: '',
     crossorigin: false,

--- a/lib/assets_context.js
+++ b/lib/assets_context.js
@@ -33,8 +33,8 @@ class Assets {
     entry = entry || this.entry;
 
     let script = '';
-    if (this.publicPath && !this.hasWebpackGlobalVariableInserted) {
-      script = inlineScriptTpl(`window.__webpack_public_path__ = '${this.publicPath}';`, this.nonce);
+    if (this.resourceBase && !this.hasWebpackGlobalVariableInserted) {
+      script = inlineScriptTpl(`window.__webpack_public_path__ = '${this.resourceBase}';`, this.nonce);
       this.hasWebpackGlobalVariableInserted = true;
     }
 

--- a/lib/assets_context.js
+++ b/lib/assets_context.js
@@ -33,8 +33,10 @@ class Assets {
     entry = entry || this.entry;
 
     let script = '';
-    if (this.resourceBase && !this.hasWebpackGlobalVariableInserted) {
-      script = inlineScriptTpl(`window.__webpack_public_path__ = '${this.resourceBase}';`, this.nonce);
+
+    const webpackPublicPath = this.config.resourcePathToURL ? this.resourceBase : this.publicPath;
+    if (webpackPublicPath && !this.hasWebpackGlobalVariableInserted) {
+      script = inlineScriptTpl(`window.__webpack_public_path__ = '${webpackPublicPath}';`, this.nonce);
       this.hasWebpackGlobalVariableInserted = true;
     }
 

--- a/test/assets.test.js
+++ b/test/assets.test.js
@@ -191,7 +191,7 @@ describe('test/assets.test.js', () => {
           .get('/')
           .expect(/<link rel="stylesheet" href="http:\/\/127.0.0.1:8000\/index.css" \/>/)
           .expect(/<script src="http:\/\/127.0.0.1:8000\/index.js"><\/script>/)
-          .expect(/<script>window.__webpack_public_path__ = 'http:\/\/127.0.0.1:8000\/';<\/script>/)
+          .expect(/<script>window.__webpack_public_path__ = '\/';<\/script>/)
           .expect(/<script>window.resourceBaseUrl = 'http:\/\/127.0.0.1:8000\/';<\/script/)
           .expect(res => {
             assert(res.text.includes('<script>(function(){window.context = JSON.parse(decodeURIComponent("%7B%22data%22%3A1%7D"));})()<\/script>'));
@@ -215,7 +215,7 @@ describe('test/assets.test.js', () => {
           .get('/')
           .expect(/<link rel="stylesheet" href="http:\/\/cdn.com\/app\/public\/index.b8e2efea.css" \/>/)
           .expect(/<script src="http:\/\/cdn.com\/app\/public\/index.c4ae6394.js"><\/script>/)
-          .expect(/<script>window.__webpack_public_path__ = 'http:\/\/cdn.com\/app\/public\/';<\/script>/)
+          .expect(/<script>window.__webpack_public_path__ = '\/app\/public\/';<\/script>/)
           .expect(/<script>window.resourceBaseUrl = 'http:\/\/cdn.com\/app\/public\/';<\/script/)
           .expect(res => {
             assert(res.text.includes('<script>(function(){window.context = JSON.parse(decodeURIComponent("%7B%22data%22%3A1%7D"));})()<\/script>'));
@@ -517,7 +517,7 @@ describe('test/assets.test.js', () => {
       const ctx = app.mockContext();
       ctx.helper.assets.setEntry('index.js');
       const script = ctx.helper.assets.getScript();
-      assert(script.includes('__webpack_public_path__ = \'http://remotehost/public\/\';'));
+      assert(script.includes('__webpack_public_path__ = \'/public\/\';'));
       assert(script.includes('src="http://remotehost/public/index.js"'));
       const style = ctx.helper.assets.getStyle();
       assert(style.includes('href="http://remotehost/index.css"'));
@@ -607,7 +607,7 @@ describe('test/assets.test.js', () => {
           .expect(/<div id="root"><\/div>/)
           .expect(/<link rel="stylesheet" href="http:\/\/127.0.0.1:8000\/index.css" \/>/)
           .expect(/<script src="http:\/\/127.0.0.1:8000\/index.js"><\/script>/)
-          .expect(/<script nonce=cspnonce>window.__webpack_public_path__ = 'http:\/\/127.0.0.1:8000\/';<\/script>/)
+          .expect(/<script nonce=cspnonce>window.__webpack_public_path__ = '\/';<\/script>/)
           .expect(res => {
             assert(res.text.includes('<script nonce=cspnonce>(function(){window.context = JSON.parse(decodeURIComponent("%7B%22data%22%3A1%7D"));})()<\/script>'));
           })
@@ -641,7 +641,7 @@ describe('test/assets.test.js', () => {
           .expect(/<div id="root"><\/div>/)
           .expect(/<link rel="stylesheet" href="http:\/\/cdn.com\/app\/public\/index.b8e2efea.css" \/>/)
           .expect(/<script src="http:\/\/cdn.com\/app\/public\/index.c4ae6394.js"><\/script>/)
-          .expect(/<script nonce=cspnonce>window.__webpack_public_path__ = 'http:\/\/cdn.com\/app\/public\/';<\/script>/)
+          .expect(/<script nonce=cspnonce>window.__webpack_public_path__ = '\/app\/public\/';<\/script>/)
           .expect(res => {
             assert(res.text.includes('<script nonce=cspnonce>(function(){window.context = JSON.parse(decodeURIComponent("%7B%22data%22%3A1%7D"));})()<\/script>'));
           })

--- a/test/assets.test.js
+++ b/test/assets.test.js
@@ -31,7 +31,7 @@ describe('test/assets.test.js', () => {
           .expect(/<div id="root"><\/div>/)
           .expect(/<link rel="stylesheet" href="http:\/\/127.0.0.1:8000\/index.css" \/>/)
           .expect(/<script src="http:\/\/127.0.0.1:8000\/index.js"><\/script>/)
-          .expect(/<script>window.__webpack_public_path__ = '\/';<\/script>/)
+          .expect(/<script>window.__webpack_public_path__ = 'http:\/\/127.0.0.1:8000\/';<\/script>/)
           .expect(res => {
             assert(res.text.includes('<script>(function(){window.context = JSON.parse(decodeURIComponent("%7B%22data%22%3A1%7D"));})()<\/script>'));
           })
@@ -65,7 +65,7 @@ describe('test/assets.test.js', () => {
           .expect(/<div id="root"><\/div>/)
           .expect(/<link rel="stylesheet" href="http:\/\/cdn.com\/app\/public\/index.b8e2efea.css" \/>/)
           .expect(/<script src="http:\/\/cdn.com\/app\/public\/index.c4ae6394.js"><\/script>/)
-          .expect(/<script>window.__webpack_public_path__ = '\/app\/public\/';<\/script>/)
+          .expect(/<script>window.__webpack_public_path__ = 'http:\/\/cdn.com\/app\/public\/';<\/script>/)
           .expect(res => {
             assert(res.text.includes('<script>(function(){window.context = JSON.parse(decodeURIComponent("%7B%22data%22%3A1%7D"));})()<\/script>'));
           })
@@ -191,7 +191,7 @@ describe('test/assets.test.js', () => {
           .get('/')
           .expect(/<link rel="stylesheet" href="http:\/\/127.0.0.1:8000\/index.css" \/>/)
           .expect(/<script src="http:\/\/127.0.0.1:8000\/index.js"><\/script>/)
-          .expect(/<script>window.__webpack_public_path__ = '\/';<\/script>/)
+          .expect(/<script>window.__webpack_public_path__ = 'http:\/\/127.0.0.1:8000\/';<\/script>/)
           .expect(/<script>window.resourceBaseUrl = 'http:\/\/127.0.0.1:8000\/';<\/script/)
           .expect(res => {
             assert(res.text.includes('<script>(function(){window.context = JSON.parse(decodeURIComponent("%7B%22data%22%3A1%7D"));})()<\/script>'));
@@ -215,7 +215,7 @@ describe('test/assets.test.js', () => {
           .get('/')
           .expect(/<link rel="stylesheet" href="http:\/\/cdn.com\/app\/public\/index.b8e2efea.css" \/>/)
           .expect(/<script src="http:\/\/cdn.com\/app\/public\/index.c4ae6394.js"><\/script>/)
-          .expect(/<script>window.__webpack_public_path__ = '\/app\/public\/';<\/script>/)
+          .expect(/<script>window.__webpack_public_path__ = 'http:\/\/cdn.com\/app\/public\/';<\/script>/)
           .expect(/<script>window.resourceBaseUrl = 'http:\/\/cdn.com\/app\/public\/';<\/script/)
           .expect(res => {
             assert(res.text.includes('<script>(function(){window.context = JSON.parse(decodeURIComponent("%7B%22data%22%3A1%7D"));})()<\/script>'));
@@ -517,7 +517,7 @@ describe('test/assets.test.js', () => {
       const ctx = app.mockContext();
       ctx.helper.assets.setEntry('index.js');
       const script = ctx.helper.assets.getScript();
-      assert(script.includes('__webpack_public_path__ = \'/public\/\';'));
+      assert(script.includes('__webpack_public_path__ = \'http://remotehost/public\/\';'));
       assert(script.includes('src="http://remotehost/public/index.js"'));
       const style = ctx.helper.assets.getStyle();
       assert(style.includes('href="http://remotehost/index.css"'));
@@ -607,7 +607,7 @@ describe('test/assets.test.js', () => {
           .expect(/<div id="root"><\/div>/)
           .expect(/<link rel="stylesheet" href="http:\/\/127.0.0.1:8000\/index.css" \/>/)
           .expect(/<script src="http:\/\/127.0.0.1:8000\/index.js"><\/script>/)
-          .expect(/<script nonce=cspnonce>window.__webpack_public_path__ = '\/';<\/script>/)
+          .expect(/<script nonce=cspnonce>window.__webpack_public_path__ = 'http:\/\/127.0.0.1:8000\/';<\/script>/)
           .expect(res => {
             assert(res.text.includes('<script nonce=cspnonce>(function(){window.context = JSON.parse(decodeURIComponent("%7B%22data%22%3A1%7D"));})()<\/script>'));
           })
@@ -641,7 +641,7 @@ describe('test/assets.test.js', () => {
           .expect(/<div id="root"><\/div>/)
           .expect(/<link rel="stylesheet" href="http:\/\/cdn.com\/app\/public\/index.b8e2efea.css" \/>/)
           .expect(/<script src="http:\/\/cdn.com\/app\/public\/index.c4ae6394.js"><\/script>/)
-          .expect(/<script nonce=cspnonce>window.__webpack_public_path__ = '\/app\/public\/';<\/script>/)
+          .expect(/<script nonce=cspnonce>window.__webpack_public_path__ = 'http:\/\/cdn.com\/app\/public\/';<\/script>/)
           .expect(res => {
             assert(res.text.includes('<script nonce=cspnonce>(function(){window.context = JSON.parse(decodeURIComponent("%7B%22data%22%3A1%7D"));})()<\/script>'));
           })

--- a/test/fixtures/apps/assets/config/config.default.js
+++ b/test/fixtures/apps/assets/config/config.default.js
@@ -11,6 +11,7 @@ exports.view = {
 };
 exports.assets = {
   publicPath: '/app/public',
+  resourcePathToURL: true,
   devServer: {
     waitStart: true,
     command: 'node ' + path.join(__dirname, '../../mocktool/server.js'),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

对于 cdn 场景来说，`__webpack_public_path__` 应该是个 url base 会更加合理
不然模版需要引入一个 resourceBase 变量

当然这个可能是个 break change
